### PR TITLE
Add NSM mention in desktop file

### DIFF
--- a/linux/org.hydrogenmusic.Hydrogen.desktop
+++ b/linux/org.hydrogenmusic.Hydrogen.desktop
@@ -27,3 +27,4 @@ Terminal=false
 StartupNotify=true
 
 Icon=org.hydrogenmusic.Hydrogen
+X-NSM-Capable=true


### PR DESCRIPTION
Hi @theGreatWhiteShark .

add NSM mention to the desktop file allows it to be listed by NSM session managers. See https://github.com/jackaudio/new-session-manager/issues/40 .

Now in RaySession, it prevents to need to check version with `hydrogen --version`.

I don't know if it is possible to build hydrogen without liblo, if it is the case, this key 'X-NSM-Capable' should be set on true or false conditionally.